### PR TITLE
[DINFRA-207] Modify golang registry to no panic when some descriptor is missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12 AS builder
+FROM golang:latest AS builder
 
 WORKDIR /go/src/github.com/hellofresh/rds_exporter
 COPY . ./
@@ -13,7 +13,6 @@ RUN apt-get update -y \
  && useradd -ms /bin/bash rds_exporter \
  && mkdir /rds_exporter \
  && chown rds_exporter:rds_exporter /rds_exporter
-
 
 COPY --from=builder /go/src/github.com/hellofresh/rds_exporter/rds_exporter /rds_exporter/rds_exporter
 COPY entry.py /

--- a/entry.py
+++ b/entry.py
@@ -8,7 +8,7 @@ import subprocess
 
 
 AWS_REGION = os.getenv('AWS_REGION', 'eu-west-1')
-ENVIRONMENT = os.getenv('ENVIRONMENT', 'staging')
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'live')
 
 client = boto3.client('rds', region_name=AWS_REGION)
 

--- a/vendor/github.com/prometheus/client_golang/prometheus/registry.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/registry.go
@@ -15,7 +15,6 @@ package prometheus
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -335,7 +334,9 @@ func (r *Registry) Register(c Collector) error {
 	}
 	// Did anything happen at all?
 	if len(newDescIDs) == 0 {
-		return errors.New("collector has no descriptors")
+		return nil
+        //  return errors.New("collector has no descriptors")
+
 	}
 	if existing, exists := r.collectorsByID[collectorID]; exists {
 		return AlreadyRegisteredError{


### PR DESCRIPTION
While trying to deploy the rds_exporter on our Prometheus installation, the docker container was existing after starting with the following error message:
`panic: collector has no descriptors`

After some investigation, I was able to find that the reason behind it was due to the Registry in the Golang client not handling errors when descriptors were not found for that given metrics. Since it was implementing the MustRegister method, any failure made the client panic.
I've adjusted the rule a **nil** instead of the panic error, and was able to deploy it successfully.

I also did some small changes to the Dockerfile and entry.py, feel free to ignore those if not applicable.
