### PR TITLE
LOGIST-3076 RDS Exporter add burst balance

### DIFF
--- a/basic/generate/main.go
+++ b/basic/generate/main.go
@@ -68,7 +68,7 @@ var (
 		// "BinLogDiskUsage",
 		// "BlockedTransactions",
 		// "BufferCacheHitRatio",
-		// "BurstBalance",
+		"BurstBalance",
 		// "CommitLatency",
 		// "CommitThroughput",
 		"CPUCreditBalance",

--- a/basic/metrics.go
+++ b/basic/metrics.go
@@ -7,6 +7,15 @@ import (
 
 var Metrics = []Metric{
 	{
+		Name: "BurstBalance",
+		Desc: prometheus.NewDesc(
+			"aws_rds_burst_balance_average",
+			"The percent of General Purpose SSD (gp2) burst-bucket I/O credits available. Units: Percent",
+			[]string{"instance", "region"},
+			map[string]string(nil),
+		),
+	},
+	{
 		Name: "CPUCreditBalance",
 		Desc: prometheus.NewDesc(
 			"aws_rds_cpu_credit_balance_average",
@@ -30,7 +39,7 @@ var Metrics = []Metric{
 			"node_cpu_average",
 			"The percentage of CPU utilization. Units: Percent",
 			[]string{"instance", "region"},
-			map[string]string{"cpu":"All", "mode":"total"},
+			map[string]string{"cpu": "All", "mode": "total"},
 		),
 	},
 	{


### PR DESCRIPTION
This PR restores the BurstBalance metric on RDS instances.

https://hellofresh.atlassian.net/browse/LOGIST-3076