### PR TITLE
overcome limitation of 100 LogStreamNames

### DIFF
--- a/enhanced/scraper.go
+++ b/enhanced/scraper.go
@@ -59,60 +59,72 @@ func (s *scraper) start(ctx context.Context, interval time.Duration, ch chan<- m
 
 // scrape performs a single scrape.
 func (s *scraper) scrape(ctx context.Context) map[string][]prometheus.Metric {
-	input := &cloudwatchlogs.FilterLogEventsInput{
-		LogGroupName:   aws.String("RDSOSMetrics"),
-		LogStreamNames: aws.StringSlice(s.logStreamNames),
-		StartTime:      aws.Int64(aws.TimeUnixMilli(s.nextStartTime)),
-	}
-	s.logger.Debugf("Requesting metrics since %s (last %s).", s.nextStartTime.UTC(), time.Since(s.nextStartTime))
 
-	// collect all returned events and metrics
 	allMetrics := make(map[string]map[time.Time][]prometheus.Metric) // ResourceID -> event timestamp -> metrics
-	collectAllMetrics := func(output *cloudwatchlogs.FilterLogEventsOutput, lastPage bool) bool {
-		for _, event := range output.Events {
-			l := s.logger.With("EventId", *event.EventId).With("LogStreamName", *event.LogStreamName)
-			l = l.With("Timestamp", aws.MillisecondsTimeValue(event.Timestamp).UTC())
-			l = l.With("IngestionTime", aws.MillisecondsTimeValue(event.IngestionTime).UTC())
 
-			var instance *sessions.Instance
-			for _, i := range s.instances {
-				if i.ResourceID == *event.LogStreamName {
-					instance = &i
-					break
-				}
-			}
-			if instance == nil {
-				l.Errorf("Failed to find instance.")
-				continue
-			}
-			l = l.With("region", instance.Region).With("instance", instance.Instance)
-
-			// l.Debugf("Message:\n%s", *event.Message)
-			osMetrics, err := parseOSMetrics([]byte(*event.Message))
-			if err != nil {
-				l.Errorf("Failed to parse metrics: %s.", err)
-				continue
-			}
-			// l.Debugf("OS Metrics:\n%#v", osMetrics)
-
-			if allMetrics[instance.ResourceID] == nil {
-				allMetrics[instance.ResourceID] = make(map[time.Time][]prometheus.Metric)
-			}
-			timestamp := aws.MillisecondsTimeValue(event.Timestamp)
-			metrics := osMetrics.makePrometheusMetrics(instance.Region)
-			allMetrics[instance.ResourceID][timestamp] = metrics
-			l.Debugf("Timestamp from Message: %s.", osMetrics.Timestamp.UTC())
+	// LogStreamNames parameter supports up to 100 items.
+	// https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_FilterLogEvents.html
+	for i := 0; len(s.logStreamNames)-(100*i) > 0; i++ {
+		slice_start := i * 100
+		slice_end := slice_start + 100
+		if slice_end > len(s.logStreamNames) {
+			slice_end = len(s.logStreamNames)
 		}
 
-		return true // continue pagination
-	}
-	if err := s.svc.FilterLogEventsPagesWithContext(ctx, input, collectAllMetrics); err != nil {
-		if awsErr, ok := err.(awserr.Error); ok {
-			if awsErr.Code() == cloudwatchlogs.ErrCodeResourceNotFoundException {
-				s.logger.Warnf("Enhanced monitoring problem: %s", awsErr.Message())
+		input := &cloudwatchlogs.FilterLogEventsInput{
+			LogGroupName:   aws.String("RDSOSMetrics"),
+			LogStreamNames: aws.StringSlice(s.logStreamNames[slice_start:slice_end]),
+			StartTime:      aws.Int64(aws.TimeUnixMilli(s.nextStartTime)),
+		}
+		s.logger.Debugf("Requesting metrics since %s (last %s).", s.nextStartTime.UTC(), time.Since(s.nextStartTime))
+
+		collectAllMetrics := func(output *cloudwatchlogs.FilterLogEventsOutput, lastPage bool) bool {
+			for _, event := range output.Events {
+				l := s.logger.With("EventId", *event.EventId).With("LogStreamName", *event.LogStreamName)
+				l = l.With("Timestamp", aws.MillisecondsTimeValue(event.Timestamp).UTC())
+				l = l.With("IngestionTime", aws.MillisecondsTimeValue(event.IngestionTime).UTC())
+
+				var instance *sessions.Instance
+				for _, i := range s.instances {
+					if i.ResourceID == *event.LogStreamName {
+						instance = &i
+						break
+					}
+				}
+				if instance == nil {
+					l.Errorf("Failed to find instance.")
+					continue
+				}
+				l = l.With("region", instance.Region).With("instance", instance.Instance)
+
+				// l.Debugf("Message:\n%s", *event.Message)
+				osMetrics, err := parseOSMetrics([]byte(*event.Message))
+				if err != nil {
+					l.Errorf("Failed to parse metrics: %s.", err)
+					continue
+				}
+				// l.Debugf("OS Metrics:\n%#v", osMetrics)
+
+				if allMetrics[instance.ResourceID] == nil {
+					allMetrics[instance.ResourceID] = make(map[time.Time][]prometheus.Metric)
+				}
+				timestamp := aws.MillisecondsTimeValue(event.Timestamp)
+				metrics := osMetrics.makePrometheusMetrics(instance.Region)
+				allMetrics[instance.ResourceID][timestamp] = metrics
+				l.Debugf("Timestamp from Message: %s.", osMetrics.Timestamp.UTC())
 			}
-		} else {
-			s.logger.Errorf("Failed to filter log events: %s.", err)
+
+			return true // continue pagination
+		}
+
+		if err := s.svc.FilterLogEventsPagesWithContext(ctx, input, collectAllMetrics); err != nil {
+			if awsErr, ok := err.(awserr.Error); ok {
+				if awsErr.Code() == cloudwatchlogs.ErrCodeResourceNotFoundException {
+					s.logger.Warnf("Enhanced monitoring problem: %s", awsErr.Message())
+				}
+			} else {
+				s.logger.Errorf("Failed to filter log events: %s.", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
`rds_exporter` crashes when there are more than 100 instances configured for enhanced monitoring.
The issue also exists in the upstream project.

RDS exporter calls cloudwatch's method `FilterLogEvents` with a parameter `LogStreamNames`,
which cannot be longer than 100 elements:
https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_FilterLogEvents.html

This PR works it around by calling FilterLogEvents multiple times.

The changes are at lines 67-76. The rest is just an indentation required to nest the logic into the loop.